### PR TITLE
Update favicon to use Keizer logo

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -30,6 +30,10 @@ export default function RootLayout({
 }>) {
 	return (
 		<html lang="en">
+				<head>
+					<link rel="icon" href="/assets/logos/logo-icon-light.svg" media="(prefers-color-scheme: light)" />
+					<link rel="icon" href="/assets/logos/logo-icon-dark.svg" media="(prefers-color-scheme: dark)" />
+				</head>
 			<body
 				className={`${geistSans.variable} ${geistMono.variable} antialiased dark:bg-black dark:text-white bg-white text-black flex items-center justify-center`}
 			>


### PR DESCRIPTION
Fixes #17

Add favicon that changes based on dark and light themes using the Keizer logo.

* Add `<link rel="icon" href="/assets/logos/logo-icon-light.svg" media="(prefers-color-scheme: light)" />` in the `<head>` section of `src/app/layout.tsx`
* Add `<link rel="icon" href="/assets/logos/logo-icon-dark.svg" media="(prefers-color-scheme: dark)" />` in the `<head>` section of `src/app/layout.tsx`

