### PR TITLE
Fix: Inconsistent Currency in PDF Invoice

### DIFF
--- a/src/components/ui/invoice/pdf/EntriesTablePDF.tsx
+++ b/src/components/ui/invoice/pdf/EntriesTablePDF.tsx
@@ -4,14 +4,15 @@ import { Entry } from "../../../../services/invoiceService";
 interface EntriesTableProps {
   entries: Entry[];
   totalAmount: string;
+  activeCurrency: string;
 }
 
-const EntriesTable = ({ entries, totalAmount }: EntriesTableProps) => {
+const EntriesTable = ({ entries, totalAmount, activeCurrency }: EntriesTableProps) => {
   const tableRows = entries.map((entry, index) => (
     <View style={styles.row} key={index}>
       <Text style={styles.description}>{entry.description}</Text>
       <Text style={styles.quantity}>{entry.quantity}</Text>
-      <Text style={styles.amount}>${(entry.amount * entry.quantity).toFixed(2)}</Text>
+      <Text style={styles.amount}>{activeCurrency}{(entry.amount * entry.quantity).toFixed(2)}</Text>
     </View>
   ));
 

--- a/src/components/ui/invoice/pdf/GenerateInvoicePDF.tsx
+++ b/src/components/ui/invoice/pdf/GenerateInvoicePDF.tsx
@@ -30,12 +30,13 @@ const GenerateInvoicePDF = ({
   totalAmount,
   totalWithTax,
 }: GenerateInvoicePDFProps) => {
+  const activeCurrency = totalAmount.substring(0, 1);
   return (
     <Document>
       <Page style={styles.page}>
         <InvoiceHeader headerDetails={headerDetails} />
         <BillingInfo billingDetails={billingDetails} />
-        <EntriesTable entries={entries} totalAmount={totalAmount} />
+        <EntriesTable entries={entries} totalAmount={totalAmount} activeCurrency={activeCurrency}/>
         <TaxDetailsTable taxDetails={taxDetails} />
         <InvoiceFooter totalWithTax={totalWithTax} customMessage={customMessage} />
       </Page>


### PR DESCRIPTION
## What does this PR do?
Initially in PDF invoice product price are hardcoded in $ currency, This PR will change the currency as per the selected acitveCurrency.

Fixes #48 

<img width="1470" alt="Screenshot 2024-12-10 at 18 57 45" src="https://github.com/user-attachments/assets/6f71d5fd-ee99-43ac-a407-f0ec69a96575">

<img width="1470" alt="Screenshot 2024-12-10 at 19 01 56" src="https://github.com/user-attachments/assets/cadb6b70-de20-444f-b6b9-93bff284b46c">


## How should this be tested?
- Open the Homepage 
- Select currency and click on 'Generate Invoice'.
- Fill up the details
- Click on 'Generate Invoice'.
- Download the PDF.
- Observe that the product prices in the invoice are displayed as per selected currency. 