### PR TITLE
feat: option to remove tax section

### DIFF
--- a/src/components/ui/invoice/pdf/GenerateInvoicePDF.tsx
+++ b/src/components/ui/invoice/pdf/GenerateInvoicePDF.tsx
@@ -37,7 +37,9 @@ const GenerateInvoicePDF = ({
         <InvoiceHeader headerDetails={headerDetails} />
         <BillingInfo billingDetails={billingDetails} />
         <EntriesTable entries={entries} totalAmount={totalAmount} activeCurrency={activeCurrency}/>
-        <TaxDetailsTable taxDetails={taxDetails} />
+        {taxDetails.length > 0 && (
+            <TaxDetailsTable taxDetails={taxDetails} />
+        )}
         <InvoiceFooter totalWithTax={totalWithTax} customMessage={customMessage} />
       </Page>
     </Document>


### PR DESCRIPTION
Resolves #70.
The tax details in pdf will not render if no tax details are added.

[Screencast from 12-27-2024 07:40:43 PM.webm](https://github.com/user-attachments/assets/9c83d613-4a30-458f-8471-2d29a21c5adc)

<sub><a href="https://huly.app/guest/keizerworks?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzZlYjVkNGYxNDRmNTg1YWU1MTE3ODUiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6Incta2VpemVyd29ya3Mta2VpemVyd29ya3MtNjc2YmIzYzQtNTg1NDc1Mzg4My00NDc3M2YifQ.82Om1MoX33JRKPW4HtGf8MWei_poka_PW4CRxpfEM8Y">Huly&reg;: <b>INVOI-75</b></a></sub>